### PR TITLE
Case sensitive user id

### DIFF
--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -26,6 +26,7 @@ MAX_ALIAS_LENGTH = 255
 
 # the maximum length for a user id is 255 characters
 MAX_USERID_LENGTH = 255
+USERID_BYTES_LENGTH = 32
 
 # The maximum length for a group id is 255 characters
 MAX_GROUPID_LENGTH = 255

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -1044,7 +1044,7 @@ class AuthHandler(BaseHandler):
         # Check if we've hit the failed ratelimit (but don't update it)
         if ratelimit:
             await self._failed_login_attempts_ratelimiter.ratelimit(
-                None, qualified_user_id.lower(), update=False
+                None, qualified_user_id, update=False
             )
 
         try:
@@ -1056,7 +1056,7 @@ class AuthHandler(BaseHandler):
             # should have happened above.
             if ratelimit:
                 await self._failed_login_attempts_ratelimiter.can_do_action(
-                    None, qualified_user_id.lower()
+                    None, qualified_user_id
                 )
             raise
 

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple
 from prometheus_client import Counter
 
 from synapse import types
-from synapse.api.constants import MAX_USERID_LENGTH, EventTypes, JoinRules, LoginType
+from synapse.api.constants import USERID_BYTES_LENGTH, EventTypes, JoinRules, LoginType
 from synapse.api.errors import AuthError, Codes, ConsentNotGivenError, SynapseError
 from synapse.appservice import ApplicationService
 from synapse.config.server import is_threepid_reserved
@@ -33,7 +33,7 @@ from synapse.replication.http.register import (
 )
 from synapse.spam_checker_api import RegistrationBehaviour
 from synapse.storage.state import StateFilter
-from synapse.types import RoomAlias, UserID, create_requester
+from synapse.types import RoomAlias, UserID, create_requester, is_valid_mxid_len
 
 from ._base import BaseHandler
 
@@ -96,8 +96,14 @@ class RegistrationHandler(BaseHandler):
         if types.contains_invalid_mxid_characters(localpart):
             raise SynapseError(
                 400,
-                "User ID can only contain characters a-z, 0-9, or '=_-./'",
+                "User ID can only contain characters in base58 encoding",
                 Codes.INVALID_USERNAME,
+            )
+
+        if not is_valid_mxid_len(localpart):
+            raise SynapseError(
+                400,
+                "User ID length must be 32 bytes", Codes.INVALID_USERNAME
             )
 
         if not localpart:
@@ -121,13 +127,6 @@ class RegistrationHandler(BaseHandler):
                 )
 
         self.check_user_id_not_appservice_exclusive(user_id)
-
-        if len(user_id) > MAX_USERID_LENGTH:
-            raise SynapseError(
-                400,
-                "User ID may not be longer than %s characters" % (MAX_USERID_LENGTH,),
-                Codes.INVALID_USERNAME,
-            )
 
         users = await self.store.get_users_by_id_case_insensitive(user_id)
         if users:

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple
 from prometheus_client import Counter
 
 from synapse import types
-from synapse.api.constants import USERID_BYTES_LENGTH, EventTypes, JoinRules, LoginType
+from synapse.api.constants import EventTypes, JoinRules, LoginType
 from synapse.api.errors import AuthError, Codes, ConsentNotGivenError, SynapseError
 from synapse.appservice import ApplicationService
 from synapse.config.server import is_threepid_reserved
@@ -102,8 +102,7 @@ class RegistrationHandler(BaseHandler):
 
         if not is_valid_mxid_len(localpart):
             raise SynapseError(
-                400,
-                "User ID length must be 32 bytes", Codes.INVALID_USERNAME
+                400, "User ID length must be 32 bytes", Codes.INVALID_USERNAME
             )
 
         if not localpart:

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -48,6 +48,7 @@ logger = logging.getLogger(__name__)
 # [1] https://pip.pypa.io/en/stable/reference/pip_install/#requirement-specifiers.
 
 REQUIREMENTS = [
+    "base58>=2.1.0",
     "jsonschema>=2.5.1",
     "frozendict>=1",
     "unpaddedbase64>=1.1.0",

--- a/synapse/rest/admin/users.py
+++ b/synapse/rest/admin/users.py
@@ -464,7 +464,7 @@ class UserRegisterServlet(RestServlet):
         register = RegisterRestServlet(self.hs)
 
         user_id = await register.registration_handler.register_user(
-            localpart=body["username"].lower(),
+            localpart=body["username"],
             password_hash=password_hash,
             admin=bool(admin),
             user_type=user_type,

--- a/synapse/rest/client/v1/login.py
+++ b/synapse/rest/client/v1/login.py
@@ -262,7 +262,7 @@ class LoginRestServlet(RestServlet):
         # too often. This happens here rather than before as we don't
         # necessarily know the user before now.
         if ratelimit:
-            await self._account_ratelimiter.ratelimit(None, user_id.lower())
+            await self._account_ratelimiter.ratelimit(None, user_id)
 
         if create_non_existent_users:
             canonical_uid = await self.auth_handler.check_user_exists(user_id)

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -480,8 +480,6 @@ class RegisterRestServlet(RestServlet):
         # Note that we treat usernames case-insensitively in login, so they are
         # free to carry on imagining that their username is CrAzYh4cKeR if that
         # keeps them happy.
-        if desired_username is not None:
-            desired_username = desired_username.lower()
 
         # Check if this account is upgrading from a guest account.
         guest_access_token = body.get("guest_access_token", None)
@@ -592,9 +590,6 @@ class RegisterRestServlet(RestServlet):
 
             desired_username = params.get("username", None)
             guest_access_token = params.get("guest_access_token", None)
-
-            if desired_username is not None:
-                desired_username = desired_username.lower()
 
             threepid = None
             if auth_result:

--- a/synapse/storage/databases/main/__init__.py
+++ b/synapse/storage/databases/main/__init__.py
@@ -328,10 +328,10 @@ class DataStore(
             # `name` is in database already in lower case
             if name:
                 filters.append("(name LIKE ? OR LOWER(displayname) LIKE ?)")
-                args.extend(["@%" + name.lower() + "%:%", "%" + name.lower() + "%"])
+                args.extend(["@%" + name + "%:%", "%" + name + "%"])
             elif user_id:
                 filters.append("name LIKE ?")
-                args.extend(["%" + user_id.lower() + "%"])
+                args.extend(["%" + user_id + "%"])
 
             if not guests:
                 filters.append("is_guest = 0")

--- a/synapse/storage/databases/main/registration.py
+++ b/synapse/storage/databases/main/registration.py
@@ -480,7 +480,7 @@ class RegistrationWorkerStore(CacheInvalidationWorkerStore):
         """
 
         def f(txn):
-            sql = "SELECT name, password_hash FROM users WHERE lower(name) = lower(?)"
+            sql = "SELECT name, password_hash FROM users WHERE name = ?"
             txn.execute(sql, (user_id,))
             return dict(txn)
 

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -14,9 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import abc
-import base58
 import re
-import string
 import sys
 from collections import namedtuple
 from typing import (
@@ -34,6 +32,7 @@ from typing import (
 )
 
 import attr
+import base58
 from signedjson.key import decode_verify_key_bytes
 from unpaddedbase64 import decode_base64
 from zope.interface import Interface
@@ -336,7 +335,7 @@ class GroupID(DomainSpecificString):
 
 
 mxid_localpart_allowed_characters = set(
-    '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+    "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 )
 
 

--- a/tests/events/test_presence_router.py
+++ b/tests/events/test_presence_router.py
@@ -137,7 +137,9 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
         self.presence_receiving_user_id = self.register_user(
             self.presence_gobbler_key, "monkey"
         )
-        self.presence_receiving_user_tok = self.login(self.presence_gobbler_key, "monkey")
+        self.presence_receiving_user_tok = self.login(
+            self.presence_gobbler_key, "monkey"
+        )
 
         # And two users who should not have any special routing
         self.other_user_one_id = self.register_user(other_user_one_key, "monkey")
@@ -252,11 +254,15 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
         self.presence_receiving_user_one_id = self.register_user(
             self.presence_gobbler1_key, "monkey"
         )
-        self.presence_receiving_user_one_tok = self.login(self.presence_gobbler1_key, "monkey")
+        self.presence_receiving_user_one_tok = self.login(
+            self.presence_gobbler1_key, "monkey"
+        )
         self.presence_receiving_user_two_id = self.register_user(
             self.presence_gobbler2_key, "monkey"
         )
-        self.presence_receiving_user_two_tok = self.login(self.presence_gobbler2_key, "monkey")
+        self.presence_receiving_user_two_tok = self.login(
+            self.presence_gobbler2_key, "monkey"
+        )
 
         # Have all three users send some presence updates
         send_presence_update(

--- a/tests/events/test_presence_router.py
+++ b/tests/events/test_presence_router.py
@@ -16,6 +16,7 @@ from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 from unittest.mock import Mock
 
 import attr
+from solana import account
 
 from synapse.api.constants import EduTypes
 from synapse.events.presence_router import PresenceRouter
@@ -86,6 +87,18 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
         presence.register_servlets,
     ]
 
+    presence_gobbler = account.Account()
+    presence_gobbler_key = str(presence_gobbler.public_key())
+
+    presence_gobbler1 = account.Account()
+    presence_gobbler1_key = str(presence_gobbler1.public_key())
+
+    presence_gobbler2 = account.Account()
+    presence_gobbler2_key = str(presence_gobbler2.public_key())
+
+    far_away_person = account.Account()
+    far_away_person_key = str(far_away_person.public_key())
+
     def make_homeserver(self, reactor, clock):
         return self.setup_test_homeserver(
             federation_transport_client=Mock(spec=["send_transaction"]),
@@ -102,7 +115,7 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
                     "module": __name__ + ".PresenceRouterTestModule",
                     "config": {
                         "users_who_should_receive_all_presence": [
-                            "@presence_gobbler:test",
+                            f"@{presence_gobbler}:test",
                         ]
                     },
                 }
@@ -115,16 +128,22 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
         presence for them, due to presence routing.
         """
         # Create a user who should receive all presence of others
+        other_user_one = account.Account()
+        other_user_one_key = str(other_user_one.public_key())
+
+        other_user_two = account.Account()
+        other_user_two_key = str(other_user_two.public_key())
+
         self.presence_receiving_user_id = self.register_user(
-            "presence_gobbler", "monkey"
+            self.presence_gobbler_key, "monkey"
         )
-        self.presence_receiving_user_tok = self.login("presence_gobbler", "monkey")
+        self.presence_receiving_user_tok = self.login(self.presence_gobbler_key, "monkey")
 
         # And two users who should not have any special routing
-        self.other_user_one_id = self.register_user("other_user_one", "monkey")
-        self.other_user_one_tok = self.login("other_user_one", "monkey")
-        self.other_user_two_id = self.register_user("other_user_two", "monkey")
-        self.other_user_two_tok = self.login("other_user_two", "monkey")
+        self.other_user_one_id = self.register_user(other_user_one_key, "monkey")
+        self.other_user_one_tok = self.login(other_user_one_key, "monkey")
+        self.other_user_two_id = self.register_user(other_user_two_key, "monkey")
+        self.other_user_two_tok = self.login(other_user_two_key, "monkey")
 
         # Put the other two users in a room with each other
         room_id = self.helper.create_room_as(
@@ -178,7 +197,7 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
             self.presence_receiving_user_id,
             self.presence_receiving_user_tok,
             "online",
-            "presence_gobbler",
+            self.presence_gobbler_key,
         )
 
         # Check that the presence receiving user gets everyone's presence
@@ -207,9 +226,9 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
                     "module": __name__ + ".PresenceRouterTestModule",
                     "config": {
                         "users_who_should_receive_all_presence": [
-                            "@presence_gobbler1:test",
-                            "@presence_gobbler2:test",
-                            "@far_away_person:island",
+                            f"@{presence_gobbler1}:test",
+                            f"@{presence_gobbler2}:test",
+                            f"@{far_away_person}:island",
                         ]
                     },
                 }
@@ -222,19 +241,22 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
         of specified local and remote users, with a custom PresenceRouter module enabled.
         """
         # Create a user who will send presence updates
-        self.other_user_id = self.register_user("other_user", "monkey")
-        self.other_user_tok = self.login("other_user", "monkey")
+        other_user_one = account.Account()
+        other_user_one_key = str(other_user_one.public_key())
+
+        self.other_user_id = self.register_user(other_user_one_key, "monkey")
+        self.other_user_tok = self.login(other_user_one_key, "monkey")
 
         # And another two users that will also send out presence updates, as well as receive
         # theirs and everyone else's
         self.presence_receiving_user_one_id = self.register_user(
-            "presence_gobbler1", "monkey"
+            self.presence_gobbler1_key, "monkey"
         )
-        self.presence_receiving_user_one_tok = self.login("presence_gobbler1", "monkey")
+        self.presence_receiving_user_one_tok = self.login(self.presence_gobbler1_key, "monkey")
         self.presence_receiving_user_two_id = self.register_user(
-            "presence_gobbler2", "monkey"
+            self.presence_gobbler2_key, "monkey"
         )
-        self.presence_receiving_user_two_tok = self.login("presence_gobbler2", "monkey")
+        self.presence_receiving_user_two_tok = self.login(self.presence_gobbler2_key, "monkey")
 
         # Have all three users send some presence updates
         send_presence_update(
@@ -287,7 +309,7 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
         self.assertEqual(len(presence_updates), 3)
 
         # Test that sending to a remote user works
-        remote_user_id = "@far_away_person:island"
+        remote_user_id = f"@{self.far_away_person}:island"
 
         # Note that due to the remote user being in our module's
         # users_who_should_receive_all_presence config, they would have


### PR DESCRIPTION
## Description:
Change register and auth handlers to support Solana public key
as user id.
Solana public key encoded in base58 and using `ed25519` curve that
have 32 bytes length of the public key.

## Implemented:
* Supporting case sensitive user_id
* Validation encoding of the user_id
* Validation length of the user_id
